### PR TITLE
typo in checking validity of `to` node in createConnection.

### DIFF
--- a/src/user/common/neat/dag.hpp
+++ b/src/user/common/neat/dag.hpp
@@ -34,7 +34,7 @@ struct DAG
             //std::cout << "Cannot create connection " << from << " -> " << to << ": " << from << " is not valid" << std::endl;
             return false;
         }
-        if (!isValid(from)) {
+        if (!isValid(to)) {
             //std::cout << "Cannot create connection " << from << " -> " << to << ": " << to << " is not valid" << std::endl;
             return false;
         }


### PR DESCRIPTION
isValid() was performed only on the `from` node, rather than on both the from and to nodes.