### PR TITLE
added config for bit depth to eliminate a video mode not available er…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@ int main()
 {
     sf::ContextSettings settings;
     settings.antialiasingLevel = 8;
+    settings.depthBits = conf::win::bit_depth;
     pez::render::WindowContextHandler app("Pendulum - Training", sf::Vector2u(conf::win::window_width, conf::win::window_height), settings, sf::Style::Fullscreen);
     training::loadResources();
     training::registerSystems();

--- a/src/user/common/configuration.hpp
+++ b/src/user/common/configuration.hpp
@@ -15,6 +15,7 @@ namespace win
 {
     constexpr uint32_t window_width  = 2560;
     constexpr uint32_t window_height = 1440;
+    constexpr uint32_t bit_depth = 24;
 
     //constexpr uint32_t window_width  = 1600;
     //constexpr uint32_t window_height = 900;


### PR DESCRIPTION
I was getting the following error:
"The requested video mode is not available, switching to a valid mode"

After some research it seems that the bit depth is wrong and I didn't see a spot in config for that so I added it.  I needed 24 bit to make it go away so I assume that 32 was the default.
